### PR TITLE
Fix anchor typo in index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,9 +82,9 @@
             
                     <h2>More Games</h2>
                     <ul>
-                                    <li><a href="memory_match.html">Memory Match Game</a>a></li>
-                                <li><a href="number_guessing.html">Number Guessing Game</a>a></li>
-                                <li><a href="rock_paper_scissors.html">Rock Paper Scissors</a>a></li>
+                                    <li><a href="memory_match.html">Memory Match Game</a></li>
+                                <li><a href="number_guessing.html">Number Guessing Game</a></li>
+                                <li><a href="rock_paper_scissors.html">Rock Paper Scissors</a></li>
                     </ul>
             </div>
     </body>


### PR DESCRIPTION
## Summary
- clean up extraneous `a>` after anchor tags in `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68852a394ff4832298253bc31b738e46